### PR TITLE
Avoid updating POSIX file attribute permissions on Windows.

### DIFF
--- a/src/main/java/io/snyk/gradle/plugin/CliDownloader.java
+++ b/src/main/java/io/snyk/gradle/plugin/CliDownloader.java
@@ -94,7 +94,9 @@ public class CliDownloader {
             FileOutputStream fos = new FileOutputStream(fileName)) {
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
             log.lifecycle("Downloading finished");
-            setFilePermissions(fileName);
+            if (!SystemUtil.isWindows()) {
+                setFilePermissions(fileName);
+            }
         }
     }
 

--- a/src/test/java/io/snyk/gradle/plugin/CliDownloaderTest.java
+++ b/src/test/java/io/snyk/gradle/plugin/CliDownloaderTest.java
@@ -16,7 +16,7 @@ public class CliDownloaderTest {
 
     Logger logger = mock(Logger.class);
     CliDownloader downloader = new CliDownloader(logger);
-    File snyk = new File("snyk");
+    File snyk = SystemUtil.isWindows() ? new File("snyk.exe") : new File("snyk");
 
     @Before
     public void init() {


### PR DESCRIPTION
This will fix the following exception in Windows:

![snyk-first-dowload-exception](https://github.com/user-attachments/assets/c95163a3-b053-4a97-9771-fb9470759caa)
