### PR TITLE
Support for Configuration cache

### DIFF
--- a/src/main/java/io/snyk/gradle/plugin/SnykBinaryTask.java
+++ b/src/main/java/io/snyk/gradle/plugin/SnykBinaryTask.java
@@ -3,22 +3,27 @@ package io.snyk.gradle.plugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
 import java.util.Optional;
 
-public class SnykBinaryTask extends DefaultTask {
+public abstract class SnykBinaryTask extends DefaultTask {
 
-    private Logger log = getProject().getLogger();
+    private Logger log = getLogger();
     private CliDownloader cliDownloader = new CliDownloader(log);
 
-    SnykExtension extension;
+    @Input
+    protected abstract Property<Boolean> getSnykAutoUpdate();
+    
+    @Input
+    protected abstract Property<Boolean> getSnykAutoDownload();
 
     @TaskAction
     public void checkSnykBinary() {
         log.debug("Snyk Binary Task");
-        extension = (SnykExtension) getProject().getExtensions().findByName("snyk");
         Optional<String> maybeVersion = getSnykVersion();
 
         String version = maybeVersion.map(this::autoUpgrade)
@@ -27,7 +32,7 @@ public class SnykBinaryTask extends DefaultTask {
     }
 
     private String autoUpgrade(String version) {
-        if (!extension.autoUpdate) {
+        if (Boolean.FALSE.equals(getSnykAutoUpdate().get())) {
             return version;
         }
 
@@ -49,7 +54,7 @@ public class SnykBinaryTask extends DefaultTask {
     }
 
     private String downloadCli() {
-        if (extension.autoDownload) {
+        if (Boolean.TRUE.equals(getSnykAutoDownload().get())) {
             return cliDownloader.downloadLatestVersion();
         }
         throw new GradleException("No Snyk binary found, set autoDownload to true to download the binary");

--- a/src/main/java/io/snyk/gradle/plugin/SnykMonitorTask.java
+++ b/src/main/java/io/snyk/gradle/plugin/SnykMonitorTask.java
@@ -3,7 +3,7 @@ package io.snyk.gradle.plugin;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 
-public class SnykMonitorTask extends SnykTask {
+public abstract class SnykMonitorTask extends SnykTask {
 
 
     @TaskAction
@@ -14,8 +14,8 @@ public class SnykMonitorTask extends SnykTask {
         Runner.Result output = runSnykCommand("monitor");
         log.lifecycle(output.output);
 
-        log.debug("severity: {}", extension.severity);
-        if (output.exitcode > 0 && extension.severity != null) {
+        log.debug("severity: {}", getSnykSeverity().getOrNull());
+        if (output.exitcode > 0 && getSnykSeverity().getOrNull() != null) {
             throw new GradleException("Snyk Test failed");
         }
     }

--- a/src/main/java/io/snyk/gradle/plugin/SnykPlugin.java
+++ b/src/main/java/io/snyk/gradle/plugin/SnykPlugin.java
@@ -12,16 +12,25 @@ public class SnykPlugin implements Plugin<Project> {
     public void apply(Project project) {
         Logger log = project.getLogger();
         log.debug("Plugin loaded");
-        project.getExtensions().create("snyk", SnykExtension.class);
+        SnykExtension extension = project.getExtensions().create("snyk", SnykExtension.class);
 
         final Configuration config = project.getConfigurations().create("dataFiles")
                 .setVisible(false)
                 .setDescription("The data artifacts to be processed for this plugin.");
 
-        SnykTestTask snykTestTask = project.getTasks().create("snyk-test", SnykTestTask.class);
-        SnykMonitorTask snykMonitorTask = project.getTasks().create("snyk-monitor", SnykMonitorTask.class);
-        SnykBinaryTask snykBinaryTaks = project.getTasks().create("snyk-check-binary", SnykBinaryTask.class);
+        SnykTestTask snykTestTask = project.getTasks().create("snyk-test", SnykTestTask.class, task -> addProperties(task, extension));
+        SnykMonitorTask snykMonitorTask = project.getTasks().create("snyk-monitor", SnykMonitorTask.class, task -> addProperties(task, extension));
+        SnykBinaryTask snykBinaryTaks = project.getTasks().create("snyk-check-binary", SnykBinaryTask.class, task -> {
+            task.getSnykAutoUpdate().set(extension.autoUpdate);
+            task.getSnykAutoDownload().set(extension.autoDownload);
+        });
         snykTestTask.dependsOn(snykBinaryTaks);
         snykMonitorTask.dependsOn(snykBinaryTaks);
     }
+    
+    private void addProperties(SnykTask task, SnykExtension extension) {
+		task.getSnykArguments().set(extension.arguments);
+		task.getSnykSeverity().set(extension.severity);
+		task.getSnykApi().set(extension.api);
+	}
 }

--- a/src/main/java/io/snyk/gradle/plugin/SnykTask.java
+++ b/src/main/java/io/snyk/gradle/plugin/SnykTask.java
@@ -3,20 +3,34 @@ package io.snyk.gradle.plugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
-public class SnykTask extends DefaultTask {
+public abstract class SnykTask extends DefaultTask {
 
 
-    protected Logger log = getProject().getLogger();
-    protected SnykExtension extension = (SnykExtension) getProject().getExtensions().findByName("snyk");
+    protected Logger log = getLogger();
+    
+    @Input
+    @Optional
+    protected abstract Property<String> getSnykArguments();
+    
+    @Input
+    @Optional
+    protected abstract Property<String> getSnykSeverity();
+    
+    @Input
+    @Optional
+    protected abstract Property<String> getSnykApi();
 
     protected Runner.Result runSnykCommand(String command) {
-        if (extension.arguments != null) {
-            command += " " + extension.arguments;
+        if (getSnykArguments().getOrNull() != null) {
+            command += " " + getSnykArguments().get();
         }
 
-        if (extension.severity != null) {
-            command += " --severity-threshold=" + extension.severity;
+        if (getSnykSeverity().getOrNull() != null) {
+            command += " --severity-threshold=" + getSnykSeverity().get();
         }
         return Runner.runSnyk(command);
     }
@@ -35,11 +49,11 @@ public class SnykTask extends DefaultTask {
             return;
         }
 
-        if (extension.api == null || extension.api.isEmpty()) {
+        if (getSnykApi().getOrNull() == null || getSnykApi().get().isEmpty()) {
             throw new GradleException("No API key found");
         }
 
-        Runner.Result authResult = Runner.runSnyk("auth "+ extension.api);
+        Runner.Result authResult = Runner.runSnyk("auth "+ getSnykApi().get());
         if (authResult.failed()) {
             throw new GradleException("snyk auth went wrong: " + authResult.getOutput());
         }

--- a/src/main/java/io/snyk/gradle/plugin/SnykTestTask.java
+++ b/src/main/java/io/snyk/gradle/plugin/SnykTestTask.java
@@ -3,7 +3,7 @@ package io.snyk.gradle.plugin;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 
-public class SnykTestTask extends SnykTask {
+public abstract class SnykTestTask extends SnykTask {
 
     @TaskAction
     public void doSnykTest() {
@@ -13,8 +13,8 @@ public class SnykTestTask extends SnykTask {
         Runner.Result output = runSnykCommand("test");
         log.lifecycle(output.output);
 
-        log.debug("severity: {}", extension.severity);
-        if (output.exitcode > 0 && extension.severity != null) {
+        log.debug("severity: {}", getSnykSeverity().getOrNull());
+        if (output.exitcode > 0 && getSnykSeverity().getOrNull() != null) {
             throw new GradleException("Snyk Test failed");
         }
     }


### PR DESCRIPTION
In a future version of Gradle the configuration cache will become mandatory.

This PR adds configuration cache compatibility with the following changes:
- Logger is retrieved with getLogger() directly without getProject()
- All variables in SnykExtension are accessed via the Property API

Tested running with Gradle 9.4.0 with the configuration cache enabled.